### PR TITLE
resolve build failures of node-java in Node v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "jdbc",
-  "version": "0.6.5-pre.0",
+  "version": "0.7.0-pre.0",
   "description": "Node Module JDBC wrapper",
   "main": "index.js",
   "dependencies": {
     "async": "~3.0.1",
-    "java": "git+https://github.com/ibmruntimes/node-java.git#node12-zos",
+    "java": "git+https://github.com/ibmruntimes/node-java.git#node14-zos",
     "lodash": "~4.17.11",
     "uuid": "^3.3.2",
     "winston": "^3.2.1"


### PR DESCRIPTION
#### Checklist
- [x] npm install && npm test passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

#### Description of change
This PR updates package.json to get a node-java version that resolves the subject issue in new branch node14-zos:
https://github.com/ibmruntimes/node-java.git

It also removes the requirement of setting LDFLAGS env var prior to building node-java or node-jdbc.

Ref node-java PR: https://github.com/ibmruntimes/node-java/pull/1

This node-jdbc from branch `zos` works with both Node v12 and v14.

For users of Node v8, branch `node8-zos` should be used, as explained in the above PR.